### PR TITLE
Worked on handling reimbursements with duplicate types in the DB

### DIFF
--- a/src/main/java/com/revature/dao/ReimbursementDaoImpl.java
+++ b/src/main/java/com/revature/dao/ReimbursementDaoImpl.java
@@ -3,6 +3,7 @@ package com.revature.dao;
 import java.util.List;
 import java.util.Optional;
 
+import org.hibernate.FlushMode;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 

--- a/src/main/java/com/revature/models/Reimbursement.java
+++ b/src/main/java/com/revature/models/Reimbursement.java
@@ -1,5 +1,6 @@
 package com.revature.models;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import javax.persistence.CascadeType;
@@ -25,9 +26,8 @@ public class Reimbursement {
 	@Column(nullable=false)
 	private double amount;
 	
-	@Column(nullable=false)
-	//@Temporal(TemporalType.DATE)
-	private String submitted;
+	@Column(nullable=false, columnDefinition="TIMESTAMP")
+	private LocalDateTime submitted;
 	
 	@Column()
 	//@Temporal(TemporalType.DATE)
@@ -46,14 +46,14 @@ public class Reimbursement {
 	private int statusId;
 	
 	//FOREIGN KEY
-	@ManyToOne(cascade=CascadeType.ALL)
+	@ManyToOne(cascade=CascadeType.REFRESH)
 	@JoinColumn(name="TypeId")
 	private ReimbursementType typeId;
 	
 	public Reimbursement() {
 	}
 
-	public Reimbursement(int id, double amount, String submitted, String resolved, String description, int authorId,
+	public Reimbursement(int id, double amount, LocalDateTime submitted, String resolved, String description, int authorId,
 			int resolverId, int statusId, ReimbursementType typeId) {
 		super();
 		Id = id;
@@ -67,7 +67,7 @@ public class Reimbursement {
 		this.typeId = typeId;
 	}
 
-	public Reimbursement(double amount, String submitted, String resolved, String description, int authorId,
+	public Reimbursement(double amount, LocalDateTime submitted, String resolved, String description, int authorId,
 			int resolverId, int statusId, ReimbursementType typeId) {
 		super();
 		this.amount = amount;
@@ -96,11 +96,11 @@ public class Reimbursement {
 		this.amount = amount;
 	}
 
-	public String getSubmitted() {
+	public LocalDateTime getSubmitted() {
 		return submitted;
 	}
 
-	public void setSubmitted(String submitted) {
+	public void setSubmitted(LocalDateTime submitted) {
 		this.submitted = submitted;
 	}
 

--- a/src/main/java/com/revature/models/ReimbursementType.java
+++ b/src/main/java/com/revature/models/ReimbursementType.java
@@ -10,7 +10,9 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Entity
 @Table(name="reimbursement_type")
@@ -21,7 +23,7 @@ public class ReimbursementType {
 	@Column(name = "reim_type_id")
 	private int reim_type_id;
 	
-	@Column(unique=true, nullable=false)
+	@Column(unique=true, nullable = false)
 	@Enumerated(EnumType.STRING)
 	private ReimbursementTypeEnum reim_type;
 

--- a/src/main/java/com/revature/service/ReimbursementService.java
+++ b/src/main/java/com/revature/service/ReimbursementService.java
@@ -2,6 +2,8 @@ package com.revature.service;
 
 import java.util.List;
 
+import org.hibernate.exception.ConstraintViolationException;
+
 import com.revature.dao.IReimbursementDao;
 import com.revature.models.Reimbursement;
 import com.revature.models.ReimbursementTypeEnum;
@@ -22,7 +24,17 @@ public class ReimbursementService {
 		// Might have to make some type of check to see if there is a reimbursement with the same 
 		// information in the DB already
 		
-		return rdao.insert(r);
+		int pk = 0;
+		
+		try {
+			
+			pk =  rdao.insert(r);
+			
+		} catch (ConstraintViolationException e) {
+			
+		}
+		
+		return pk;
 	}
 	
 	public List<Reimbursement> getUserReimbursements(int id) {

--- a/src/main/java/com/revature/web/RequestHelper.java
+++ b/src/main/java/com/revature/web/RequestHelper.java
@@ -2,6 +2,8 @@ package com.revature.web;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,6 +11,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
+import org.hibernate.exception.ConstraintViolationException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.revature.dao.ReimbursementDaoImpl;
@@ -128,8 +132,28 @@ public class RequestHelper {
 		ReimbursementTypeEnum typeEnum = ReimbursementTypeEnum.valueOf(request.getParameter("reimbursement-type"));
 		ReimbursementType type = new ReimbursementType(typeEnum);
 		
-		Reimbursement r = new Reimbursement(amount, "null", "null", description, u.getId(), 0, 0, type);
+		LocalDateTime curTime = LocalDateTime.now();
 		
+		curTime = curTime.truncatedTo(ChronoUnit.SECONDS);
+		
+		// Set the types id to whatever the reimbursement-type is
+		switch (typeEnum.toString()) {
+		
+		case "FOOD":
+			type.setReim_type_id(1);
+			break;
+		case "LODGING":
+			type.setReim_type_id(2);
+			break;
+		case "TRAVEL":
+			type.setReim_type_id(3);
+			break;
+		default:
+			type.setReim_type_id(4);	
+		}
+		
+		Reimbursement r = new Reimbursement(amount, curTime, "null", description, u.getId(), 0, 0, type);	
+			
 		int pk = rServ.createReimbursement(r);
 		
 		if (pk > 0) {


### PR DESCRIPTION
Reimbursement Model - Changed the object type of submitted from String to LocalDateTime and added a "TIMESTAMP" 
column definition to it. Had to change wherever the model was constructed throughout the project as well.

Had to manually drop the reimbuserment_type table and add each type by hand. Before hibernate would insert reimbursement
types into the table, despite there being an existing type with the same name, this threw an error  because the
type was set to unique. Found a workaround using a switch statement in the RequestHelper but not sure if this 
is good to do. I asked Sophia this question hopefully she helps us out.